### PR TITLE
Fix equality overloads of binary operators

### DIFF
--- a/src/Propositions/BinaryOperations/Conjunction.cpp
+++ b/src/Propositions/BinaryOperations/Conjunction.cpp
@@ -6,10 +6,10 @@ std::string Conjunction::getString() const {
 
 bool Conjunction::operator==(const std::shared_ptr<WellFormedFormula> &other) const {
     if (auto otherConjunction = std::dynamic_pointer_cast<Conjunction>(other)) {
-        return ((this->leftOperand == otherConjunction->leftOperand) &&
-                (this->rightOperand == otherConjunction->rightOperand)) ||
-               ((this->leftOperand == otherConjunction->rightOperand) &&
-                (this->rightOperand == otherConjunction->leftOperand));
+        return ((*this->leftOperand == otherConjunction->leftOperand) &&
+                (*this->rightOperand == otherConjunction->rightOperand)) ||
+               ((*this->leftOperand == otherConjunction->rightOperand) &&
+                (*this->rightOperand == otherConjunction->leftOperand));
     }
     return false;
 }

--- a/src/Propositions/BinaryOperations/Disjunction.cpp
+++ b/src/Propositions/BinaryOperations/Disjunction.cpp
@@ -6,10 +6,10 @@ std::string Disjunction::getString() const {
 
 bool Disjunction::operator==(const std::shared_ptr<WellFormedFormula> &other) const {
     if (auto otherDisjunction = std::dynamic_pointer_cast<Disjunction>(other)) {
-        return ((this->leftOperand == otherDisjunction->leftOperand) &&
-                (this->rightOperand == otherDisjunction->rightOperand)) ||
-               ((this->leftOperand == otherDisjunction->rightOperand) &&
-                (this->rightOperand == otherDisjunction->leftOperand));
+        return ((*this->leftOperand == otherDisjunction->leftOperand) &&
+                (*this->rightOperand == otherDisjunction->rightOperand)) ||
+               ((*this->leftOperand == otherDisjunction->rightOperand) &&
+                (*this->rightOperand == otherDisjunction->leftOperand));
     }
     return false;
 }

--- a/src/Propositions/BinaryOperations/Equivalence.cpp
+++ b/src/Propositions/BinaryOperations/Equivalence.cpp
@@ -7,10 +7,10 @@ std::string Equivalence::getString() const {
 
 bool Equivalence::operator==(const std::shared_ptr<WellFormedFormula> &other) const {
     if (auto otherEquivalence = std::dynamic_pointer_cast<Equivalence>(other)) {
-        return ((this->leftOperand == otherEquivalence->leftOperand) &&
-                (this->rightOperand == otherEquivalence->rightOperand)) ||
-               ((this->leftOperand == otherEquivalence->rightOperand) &&
-                (this->rightOperand == otherEquivalence->leftOperand));
+        return ((*this->leftOperand == otherEquivalence->leftOperand) &&
+                (*this->rightOperand == otherEquivalence->rightOperand)) ||
+               ((*this->leftOperand == otherEquivalence->rightOperand) &&
+                (*this->rightOperand == otherEquivalence->leftOperand));
     }
     return false;
 }

--- a/src/Propositions/BinaryOperations/Implication.cpp
+++ b/src/Propositions/BinaryOperations/Implication.cpp
@@ -6,8 +6,8 @@ std::string Implication::getString() const {
 
 bool Implication::operator==(const std::shared_ptr<WellFormedFormula> &other) const {
     if (auto otherImplication = std::dynamic_pointer_cast<Implication>(other)) {
-        return (this->leftOperand == otherImplication->leftOperand) &&
-               (this->rightOperand == otherImplication->rightOperand);
+        return (*this->leftOperand == otherImplication->leftOperand) &&
+               (*this->rightOperand == otherImplication->rightOperand);
     }
     return false;
 }

--- a/test/Propositions/BinaryOperations/Conjunction.cpp
+++ b/test/Propositions/BinaryOperations/Conjunction.cpp
@@ -3,13 +3,15 @@
 #include "Propositions/Variable.h"
 
 TEST(ConjunctionTest, CorrectEqualityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto conjunction1 = std::make_shared<Conjunction>(A, B);
-    auto conjunction2 = std::make_shared<Conjunction>(A, B);
-    auto conjunction3 = std::make_shared<Conjunction>(B, A);
-    auto conjunction4 = std::make_shared<Conjunction>(A, C);
+    auto conjunction1 = std::make_shared<Conjunction>(A1, B1);
+    auto conjunction2 = std::make_shared<Conjunction>(A2, B2);
+    auto conjunction3 = std::make_shared<Conjunction>(B1, A1);
+    auto conjunction4 = std::make_shared<Conjunction>(A1, C);
 
     ASSERT_TRUE((*conjunction1) == conjunction2);
     ASSERT_TRUE((*conjunction1) == conjunction3);
@@ -17,13 +19,15 @@ TEST(ConjunctionTest, CorrectEqualityCheck) {
 }
 
 TEST(ConjunctionTest, CorrectInequalityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto conjunction1 = std::make_shared<Conjunction>(A, B);
-    auto conjunction2 = std::make_shared<Conjunction>(A, B);
-    auto conjunction3 = std::make_shared<Conjunction>(B, A);
-    auto conjunction4 = std::make_shared<Conjunction>(A, C);
+    auto conjunction1 = std::make_shared<Conjunction>(A1, B1);
+    auto conjunction2 = std::make_shared<Conjunction>(A2, B2);
+    auto conjunction3 = std::make_shared<Conjunction>(B1, A1);
+    auto conjunction4 = std::make_shared<Conjunction>(A1, C);
 
     ASSERT_FALSE((*conjunction1) != conjunction2);
     ASSERT_FALSE((*conjunction1) != conjunction3);

--- a/test/Propositions/BinaryOperations/Disjunction.cpp
+++ b/test/Propositions/BinaryOperations/Disjunction.cpp
@@ -3,13 +3,15 @@
 #include "Propositions/BinaryOperations/Disjunction.h"
 
 TEST(DisjunctionTest, CorrectEqualityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto disjunction1 = std::make_shared<Disjunction>(A, B);
-    auto disjunction2 = std::make_shared<Disjunction>(A, B);
-    auto disjunction3 = std::make_shared<Disjunction>(B, A);
-    auto disjunction4 = std::make_shared<Disjunction>(A, C);
+    auto disjunction1 = std::make_shared<Disjunction>(A1, B1);
+    auto disjunction2 = std::make_shared<Disjunction>(A2, B2);
+    auto disjunction3 = std::make_shared<Disjunction>(B1, A1);
+    auto disjunction4 = std::make_shared<Disjunction>(A1, C);
 
     ASSERT_TRUE((*disjunction1) == disjunction2);
     ASSERT_TRUE((*disjunction1) == disjunction3);
@@ -17,13 +19,15 @@ TEST(DisjunctionTest, CorrectEqualityCheck) {
 }
 
 TEST(DisjunctionTest, CorrectInequalityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto disjunction1 = std::make_shared<Disjunction>(A, B);
-    auto disjunction2 = std::make_shared<Disjunction>(A, B);
-    auto disjunction3 = std::make_shared<Disjunction>(B, A);
-    auto disjunction4 = std::make_shared<Disjunction>(A, C);
+    auto disjunction1 = std::make_shared<Disjunction>(A1, B1);
+    auto disjunction2 = std::make_shared<Disjunction>(A2, B2);
+    auto disjunction3 = std::make_shared<Disjunction>(B1, A1);
+    auto disjunction4 = std::make_shared<Disjunction>(A1, C);
 
     ASSERT_FALSE((*disjunction1) != disjunction2);
     ASSERT_FALSE((*disjunction1) != disjunction3);

--- a/test/Propositions/BinaryOperations/Equivalence.cpp
+++ b/test/Propositions/BinaryOperations/Equivalence.cpp
@@ -3,13 +3,15 @@
 #include "Propositions/Variable.h"
 
 TEST(EquivalenceTest, CorrectEqualityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto equivalence1 = std::make_shared<Equivalence>(A, B);
-    auto equivalence2 = std::make_shared<Equivalence>(A, B);
-    auto equivalence3 = std::make_shared<Equivalence>(B, A);
-    auto equivalence4 = std::make_shared<Equivalence>(A, C);
+    auto equivalence1 = std::make_shared<Equivalence>(A1, B1);
+    auto equivalence2 = std::make_shared<Equivalence>(A2, B2);
+    auto equivalence3 = std::make_shared<Equivalence>(B1, A1);
+    auto equivalence4 = std::make_shared<Equivalence>(A1, C);
 
     ASSERT_TRUE((*equivalence1) == equivalence2);
     ASSERT_TRUE((*equivalence1) == equivalence3);
@@ -17,13 +19,15 @@ TEST(EquivalenceTest, CorrectEqualityCheck) {
 }
 
 TEST(EquivalenceTest, CorrectInequalityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto equivalence1 = std::make_shared<Equivalence>(A, B);
-    auto equivalence2 = std::make_shared<Equivalence>(A, B);
-    auto equivalence3 = std::make_shared<Equivalence>(B, A);
-    auto equivalence4 = std::make_shared<Equivalence>(A, C);
+    auto equivalence1 = std::make_shared<Equivalence>(A1, B1);
+    auto equivalence2 = std::make_shared<Equivalence>(A2, B2);
+    auto equivalence3 = std::make_shared<Equivalence>(B1, A1);
+    auto equivalence4 = std::make_shared<Equivalence>(A1, C);
 
     ASSERT_FALSE((*equivalence1) != equivalence2);
     ASSERT_FALSE((*equivalence1) != equivalence3);

--- a/test/Propositions/BinaryOperations/Implication.cpp
+++ b/test/Propositions/BinaryOperations/Implication.cpp
@@ -3,13 +3,15 @@
 #include "Propositions/Variable.h"
 
 TEST(ImplicationTest, CorrectEqualityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto implication1 = std::make_shared<Implication>(A, B);
-    auto implication2 = std::make_shared<Implication>(A, B);
-    auto implication3 = std::make_shared<Implication>(B, A);
-    auto implication4 = std::make_shared<Implication>(A, C);
+    auto implication1 = std::make_shared<Implication>(A1, B1);
+    auto implication2 = std::make_shared<Implication>(A2, B2);
+    auto implication3 = std::make_shared<Implication>(B1, A1);
+    auto implication4 = std::make_shared<Implication>(A1, C);
 
     ASSERT_TRUE((*implication1) == implication2);
     ASSERT_FALSE((*implication1) == implication3);
@@ -17,13 +19,15 @@ TEST(ImplicationTest, CorrectEqualityCheck) {
 }
 
 TEST(ImplicationTest, CorrectInequalityCheck) {
-    auto A = std::make_shared<Variable>('A');
-    auto B = std::make_shared<Variable>('B');
+    auto A1 = std::make_shared<Variable>('A');
+    auto A2 = std::make_shared<Variable>('A');
+    auto B1 = std::make_shared<Variable>('B');
+    auto B2 = std::make_shared<Variable>('B');
     auto C = std::make_shared<Variable>('C');
-    auto implication1 = std::make_shared<Implication>(A, B);
-    auto implication2 = std::make_shared<Implication>(A, B);
-    auto implication3 = std::make_shared<Implication>(B, A);
-    auto implication4 = std::make_shared<Implication>(A, C);
+    auto implication1 = std::make_shared<Implication>(A1, B1);
+    auto implication2 = std::make_shared<Implication>(A2, B2);
+    auto implication3 = std::make_shared<Implication>(B1, A1);
+    auto implication4 = std::make_shared<Implication>(A1, C);
 
     ASSERT_FALSE((*implication1) != implication2);
     ASSERT_TRUE((*implication1) != implication3);


### PR DESCRIPTION
Fixes the `operator==` overloads to compare propositions instead of `shared_ptr`